### PR TITLE
Qt5 widgets bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(rqt_rviz_HDRS
 )
 
 if("${qt_gui_cpp_USE_QT_MAJOR_VERSION} " STREQUAL "5 ")
-  find_package(Qt5Widgets REQUIRED)
+  find_package(Qt5 REQUIRED COMPONENTS Widgets)
   qt5_wrap_cpp(rqt_rviz_MOCS ${rqt_rviz_HDRS})
   set(qt_LIBRARIES Qt5::Widgets)
 else()

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>boost</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>rviz</build_depend>


### PR DESCRIPTION
This gets rqt_rviz building on Zesty. Tested locally on Xenial, Zesty and Stretch.
@dirk-thomas I don't know if it's the "proper" fix though, I could use your input on this :)