### PR TITLE
WIP: Towards config file for the plugin and hide_menu saving

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,12 @@ catkin_package(
 catkin_python_setup()
 
 set(rqt_rviz_SRCS
+  src/rqt_rviz/config_dialog.cpp
   src/rqt_rviz/rviz.cpp
 )
 
 set(rqt_rviz_HDRS
+  include/rqt_rviz/config_dialog.h
   include/rqt_rviz/rviz.h
 )
 

--- a/include/rqt_rviz/config_dialog.h
+++ b/include/rqt_rviz/config_dialog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Dorian Scholz, TU Darmstadt
+ * Copyright (c) 2018, Open Source Robotics Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,59 +30,55 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef rqt_rviz__RViz_H
-#define rqt_rviz__RViz_H
+#ifndef rqt_rviz__ConfigDialog_H
+#define rqt_rviz__ConfigDialog_H
 
-#include <rqt_gui_cpp/plugin.h>
-#include <rviz/visualization_frame.h>
-#include <OGRE/OgreLog.h>
+#include <QCheckBox>
+#include <QDialog>
+#include <QLineEdit>
 
-#include <QDockWidget>
-#include <QMenuBar>
+namespace rqt_rviz
+{
 
-namespace rqt_rviz {
-
-class RViz
-  : public rqt_gui_cpp::Plugin
+class ConfigDialog : public QDialog
 {
 
   Q_OBJECT
 
 public:
 
-  RViz();
+  /** @brief Constructor. */
+  ConfigDialog();
 
-  ~RViz();
+  /** @brief Destructor. */
+  ~ConfigDialog();
 
-  virtual void initPlugin(qt_gui_cpp::PluginContext& context);
- 
-  virtual void saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const;
+  /** @brief Populate the file path line edit. */
+  void SetFile(const std::string& file);
 
-  virtual void restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings);
+  /** @brief Get the file path entered by the user. */
+  std::string GetFile() const;
 
-  bool hasConfiguration() const;
+  /** @brief Get the hide menu option. */
+  bool GetHide() const;
 
-  void triggerConfiguration();
+  /** @brief Set the hide menu option. */
+  void SetHide(const bool hide);
 
-  virtual bool eventFilter(QObject* watched, QEvent* event);
+private slots:
 
-protected:
-  void parseArguments();
+  /** @brief Callback when the browse button is pressed. */
+  void OnBrowse();
 
-  qt_gui_cpp::PluginContext* context_;
+private:
 
-  rviz::VisualizationFrame* widget_;
+  /** @brief Holds the file path. */
+  QLineEdit* file_edit_;
 
-  Ogre::Log* log_;
-
-  bool hide_menu_;
-  std::string display_config_;
-  bool ogre_log_;
-
-  /** @brief Pointer to menu bar. */
-  QMenuBar* menu_bar_;
+  /** @brief Holds the boolean for whether to hide the menu. */
+  QCheckBox* hide_box_;
 };
 
 }
 
-#endif // rqt_rviz__RViz_H
+#endif // rqt_rviz__ConfigDialog_H

--- a/include/rqt_rviz/rviz.h
+++ b/include/rqt_rviz/rviz.h
@@ -54,6 +54,14 @@ public:
   ~RViz();
 
   virtual void initPlugin(qt_gui_cpp::PluginContext& context);
+ 
+  virtual void saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const;
+
+  virtual void restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings);
+
+  bool hasConfiguration() const;
+
+  void triggerConfiguration();
 
   virtual bool eventFilter(QObject* watched, QEvent* event);
 

--- a/src/rqt_rviz/config_dialog.cpp
+++ b/src/rqt_rviz/config_dialog.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <QFileDialog>
+#include <QGridLayout>
+#include <QLabel>
+#include <QPushButton>
+
+#include <rqt_rviz/config_dialog.h>
+
+namespace rqt_rviz {
+
+ConfigDialog::ConfigDialog()
+{
+  // Window configurations
+  this->setWindowTitle(tr("Choose configuration"));
+  this->setWindowFlags(Qt::Window | Qt::WindowCloseButtonHint |
+      Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
+
+  // File
+  QLabel* file_label = new QLabel("File path");
+  file_label->setToolTip("Full path to file");
+  file_label->setMaximumWidth(100);
+
+  file_edit_ = new QLineEdit;
+  file_edit_->setMinimumWidth(300);
+
+  QPushButton* browse_button = new QPushButton(tr("Browse"));
+  connect(browse_button, SIGNAL(clicked()), this, SLOT(OnBrowse()));
+
+  // Hide menu
+  QLabel* hide_label = new QLabel("Hide menu");
+  hide_label->setToolTip("Check to hide RViz's top menu bar");
+  hide_label->setMaximumWidth(100);
+
+  hide_box_ = new QCheckBox();
+
+  // Buttons
+  QPushButton* cancel_button = new QPushButton(tr("&Cancel"));
+  this->connect(cancel_button, SIGNAL(clicked()), this, SLOT(close()));
+
+  QPushButton* apply_button = new QPushButton(tr("&Apply"));
+  apply_button->setDefault(true);
+  this->connect(apply_button, SIGNAL(clicked()), this, SLOT(accept()));
+
+  QHBoxLayout* buttons_layout = new QHBoxLayout;
+  buttons_layout->addWidget(cancel_button);
+  buttons_layout->addWidget(apply_button);
+
+  // Layout
+  QGridLayout* main_layout = new QGridLayout();
+
+  main_layout->addWidget(file_label, 0, 0);
+  main_layout->addWidget(file_edit_, 0, 1);
+  main_layout->addWidget(browse_button, 0, 2);
+
+  main_layout->addWidget(hide_label, 1, 0);
+  main_layout->addWidget(hide_box_, 1, 1);
+  main_layout->setAlignment(hide_box_, Qt::AlignLeft);
+
+  main_layout->addLayout(buttons_layout, 2, 0, 1, 3);
+
+  this->setLayout(main_layout);
+}
+
+ConfigDialog::~ConfigDialog()
+{
+}
+
+void ConfigDialog::OnBrowse()
+{
+  QString filename = QFileDialog::getOpenFileName(0,
+    tr("Choose config file:"), "", tr("Rviz config file (*.rviz)"));
+
+  file_edit_->setText(filename);
+}
+
+std::string ConfigDialog::GetFile() const
+{
+  return file_edit_->text().toStdString();
+}
+
+void ConfigDialog::SetFile(const std::string& file)
+{
+  file_edit_->setText(QString::fromStdString(file));
+}
+
+bool ConfigDialog::GetHide() const
+{
+  return hide_box_->isChecked();
+}
+
+void ConfigDialog::SetHide(const bool hide)
+{
+  hide_box_->setChecked(hide);
+}
+
+}
+

--- a/src/rqt_rviz/config_dialog.cpp
+++ b/src/rqt_rviz/config_dialog.cpp
@@ -49,7 +49,6 @@ ConfigDialog::ConfigDialog()
   // File
   QLabel* file_label = new QLabel("File path");
   file_label->setToolTip("Full path to file");
-  file_label->setMaximumWidth(100);
 
   file_edit_ = new QLineEdit;
   file_edit_->setMinimumWidth(300);
@@ -60,7 +59,6 @@ ConfigDialog::ConfigDialog()
   // Hide menu
   QLabel* hide_label = new QLabel("Hide menu");
   hide_label->setToolTip("Check to hide RViz's top menu bar");
-  hide_label->setMaximumWidth(100);
 
   hide_box_ = new QCheckBox();
 
@@ -88,6 +86,7 @@ ConfigDialog::ConfigDialog()
   main_layout->setAlignment(hide_box_, Qt::AlignLeft);
 
   main_layout->addLayout(buttons_layout, 2, 0, 1, 3);
+  main_layout->setColumnStretch(1, 2);
 
   this->setLayout(main_layout);
 }

--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -33,15 +33,14 @@
 #include <OGRE/OgreLogManager.h>
 
 #include <QCloseEvent>
-#include <QMenuBar>
 #include <QFileDialog>
 
 #include <pluginlib/class_list_macros.h>
 #include <boost/program_options.hpp>
 #include <fstream>
 
+#include <rqt_rviz/config_dialog.h>
 #include <rqt_rviz/rviz.h>
-
 
 namespace rqt_rviz {
 
@@ -83,10 +82,10 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   widget_ = new rviz::VisualizationFrame();
 
   // create own menu bar to disable native menu bars on Unity and Mac
-  QMenuBar* menu_bar = new QMenuBar();
-  menu_bar->setNativeMenuBar(false);
-  menu_bar->setVisible(!hide_menu_);
-  widget_->setMenuBar(menu_bar);
+  menu_bar_ = new QMenuBar();
+  menu_bar_->setNativeMenuBar(false);
+  menu_bar_->setVisible(!hide_menu_);
+  widget_->setMenuBar(menu_bar_);
 
   widget_->initialize(display_config_.c_str());
 
@@ -94,7 +93,7 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   QMenu* menu = 0;
   {
     // find first menu in menu bar
-    const QObjectList& children = menu_bar->children();
+    const QObjectList& children = menu_bar_->children();
     for (QObjectList::const_iterator it = children.begin(); !menu && it != children.end(); it++)
     {
       menu = dynamic_cast<QMenu*>(*it);
@@ -132,7 +131,7 @@ void RViz::parseArguments()
   const QStringList& qargv = context_->argv();
 
   const int argc = qargv.count();
-  
+
   // temporary storage for args obtained from qargv - since each QByteArray
   // owns its storage, we need to keep these around until we're done parsing
   // args using boost::program_options
@@ -160,11 +159,8 @@ void RViz::parseArguments()
 
     if (vm.count("hide-menu"))
     {
-      ROS_INFO_STREAM("HIDE MENU TRUE");
       hide_menu_ = true;
     }
-    else
-      ROS_INFO_STREAM("HIDE MENU FALSE");
 
     if (vm.count("display-config"))
     {
@@ -182,77 +178,51 @@ void RViz::parseArguments()
   }
 }
 
-void RViz::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const {
+void RViz::saveSettings(qt_gui_cpp::Settings& plugin_settings,
+                        qt_gui_cpp::Settings& instance_settings) const
+{
   instance_settings.setValue("rviz_config_file", display_config_.c_str());
   instance_settings.setValue("hide_menu", hide_menu_);
 }
 
-void RViz::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings) {
-  if(instance_settings.contains("rviz_config_file")) {
+void RViz::restoreSettings(const qt_gui_cpp::Settings& plugin_settings,
+                           const qt_gui_cpp::Settings& instance_settings)
+{
+  if (instance_settings.contains("rviz_config_file"))
+  {
     display_config_ = instance_settings.value("rviz_config_file").toString().toLocal8Bit().constData();;
-    // Read config from file
-    std::ifstream cfgFile;
-    cfgFile.open(display_config_.c_str(), std::ifstream::in);
-    if (cfgFile.good()){
-      std::stringstream strStream;
-      strStream << cfgFile.rdbuf();
-      display_config_ = strStream.str();
-      // Set it
-      // No idea how to do this properly
-    }
-    else
-      ROS_ERROR_STREAM("Non existing config file: " << display_config_);
+    widget_->loadDisplayConfig(display_config_.c_str());
   }
 
-  if(instance_settings.contains("hide_menu")) {
-    bool hide_menu_saved_ = instance_settings.value("hide_menu").toBool();
-    ROS_INFO_STREAM("We would set hide_menu to: " << hide_menu_);
-  //   QMenuBar* menu_bar = new QMenuBar();
-  //   menu_bar->setNativeMenuBar(false);
-  //   // To deal with the commandline arguments, they take precedence
-  //   if (hide_menu_saved_ && !hide_menu_){
-  //       hide_menu_ = hide_menu_saved_;
-  //     }
-  //   menu_bar->setVisible(!hide_menu_);
-  //   widget_->setMenuBar(menu_bar);
-    }
-
+  if (instance_settings.contains("hide_menu"))
+  {
+    bool hide_menu_ = instance_settings.value("hide_menu").toBool();
+    menu_bar_->setVisible(!hide_menu_);
+  }
 }
 
-bool RViz::hasConfiguration() const{
+bool RViz::hasConfiguration() const
+{
   return true;
 }
 
-void RViz::triggerConfiguration(){
-  // Create a dialog with the config file and hide menu
-  // It would be nice to be able to specify a path in a ROS package
-  // way, e.g.: $(find mypkg)/config/cfg.rviz
-  // or a command to be able to do `rospack find mypkg`/config/cfg.rviz
-  // so people could ship a launchfile with a perspective
-  // that can be used in other machines
-  // (otherwise the config would be like /home/user/cfg.rviz)
+void RViz::triggerConfiguration()
+{
+  // Dialog
+  ConfigDialog *dialog = new ConfigDialog();
+  dialog->SetFile(display_config_);
+  dialog->SetHide(hide_menu_);
 
-  // I have no clue how to implement this in C++ and I haven't found a single example
-  ROS_INFO_STREAM("Clicked configuration!");
-  // Ideally we want to show a custom dialog with the checkbox for the hide menu...
-  // this is all I could do
-  QString filename = QFileDialog::getOpenFileName(0,
-    tr("Choose config file:"), "", tr("Rviz config file (*.rviz)"));
-  ROS_INFO_STREAM("Chosen: " << filename.toLocal8Bit().constData());
-  // if the user actually chose a file
-  if (filename.size() > 0){
-    std::ifstream cfgFile;
-    cfgFile.open(filename.toLocal8Bit().constData(), std::ifstream::in);
-    // Check if the file exists
-    if (cfgFile.good()){
-      // Set it
-      display_config_ = filename.toLocal8Bit().constData();
-      // No idea how to do this properly
-    }
-  }
+  if (dialog->exec() != QDialog::Accepted)
+    return;
 
+  // Store and apply
+  display_config_ = dialog->GetFile();
+  hide_menu_ = dialog->GetHide();
+
+  widget_->loadDisplayConfig(display_config_.c_str());
+  menu_bar_->setVisible(!hide_menu_);
 }
-
 
 bool RViz::eventFilter(QObject* watched, QEvent* event)
 {


### PR DESCRIPTION
It would be so nice to have this feature, so we can just build a nice interface for any robot with a few rqt plugins.

I take too long with C++ (and I'm very unfamiliar with Rviz and Qt on C++) so in this PR I hope someone may help on getting this implemented.

The issues I could not solve are:
* Creating a custom dialog for choosing a Rviz config file and if to hide the top menu bar (the one that has `File Panels Help`), in this branch I just show a FileDialog.
* On a new config file chosen on the dialog, refresh the widget with the new config (everything I tried, just crashed).
* Dealing with the precedence of the command line arguments to set the `hide_menu` and the rviz config.