### PR TITLE
Use std::vector for variable length arrays.

### DIFF
--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -136,7 +136,7 @@ void RViz::parseArguments()
   // owns its storage, we need to keep these around until we're done parsing
   // args using boost::program_options
   std::vector<QByteArray> argv_array;
-  std::vector<const char *> argv(argc+1, nullptr);
+  std::vector<const char *> argv(argc+1);
   argv[0] = ""; // dummy program name
 
   for (int i = 0; i < argc; ++i)

--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -136,7 +136,7 @@ void RViz::parseArguments()
   // owns its storage, we need to keep these around until we're done parsing
   // args using boost::program_options
   std::vector<QByteArray> argv_array;
-  const char *argv[argc+1];
+  std::vector<const char *> argv(argc+1, nullptr);
   argv[0] = ""; // dummy program name
 
   for (int i = 0; i < argc; ++i)
@@ -154,7 +154,7 @@ void RViz::parseArguments()
 
   try
   {
-    po::store(po::parse_command_line(argc+1, argv, options), vm);
+    po::store(po::parse_command_line(argc+1, argv.data(), options), vm);
     po::notify(vm);
 
     if (vm.count("hide-menu"))


### PR DESCRIPTION
Some compilers (For example, MSVC) don't support variable length arrays feature like G++. Rework the code to use std::vector instead for between cross-compiling.