### PR TITLE
Several improvements for Melodic + Noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ project(rqt_rviz)
 # Load catkin and all dependencies required for this package
 
 find_package(Boost REQUIRED COMPONENTS program_options)
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp rviz)
 catkin_package(	
@@ -39,7 +38,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} ${rqt_rviz_SRCS} ${rqt_rviz_MOCS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${qt_LIBRARIES} ${Boost_LIBRARIES})
 
-find_package(class_loader)
+find_package(class_loader REQUIRED)
 class_loader_hide_library_symbols(${PROJECT_NAME})
 
 install(FILES plugin.xml

--- a/include/rqt_rviz/rviz.h
+++ b/include/rqt_rviz/rviz.h
@@ -55,7 +55,7 @@ public:
   ~RViz();
 
   virtual void initPlugin(qt_gui_cpp::PluginContext& context);
- 
+
   virtual void saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const;
 
   virtual void restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings);
@@ -65,6 +65,9 @@ public:
   void triggerConfiguration();
 
   virtual bool eventFilter(QObject* watched, QEvent* event);
+
+protected Q_SLOTS:
+  void onDisplayConfigChanged(const QString& fullpath);
 
 protected:
   void parseArguments();

--- a/package.xml
+++ b/package.xml
@@ -4,6 +4,7 @@
   <description>rqt_rviz provides a GUI plugin embedding <a href = "http://www.ros.org/wiki/rviz">RViz</a>.
     Note that this rqt plugin does NOT supersede RViz but depends on it.
   </description>
+  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
   <maintainer email="louise@osrfoundation.org">Louise Poubel</maintainer>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend>class_loader</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>

--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -87,6 +87,7 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   menu_bar_->setVisible(!hide_menu_);
   widget_->setMenuBar(menu_bar_);
   widget_->setSplashPath(QString());
+  connect(widget_, &rviz::VisualizationFrame::displayConfigFileChanged, this, &RViz::onDisplayConfigChanged);
 
   widget_->initialize(display_config_.c_str());
 
@@ -104,6 +105,10 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
 
   // trigger deleteLater for plugin when widget or frame is closed
   widget_->installEventFilter(this);
+}
+
+void RViz::onDisplayConfigChanged(const QString& fullpath) {
+  display_config_ = fullpath.toStdString();
 }
 
 void RViz::parseArguments()

--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -96,11 +96,6 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   if (action)
     action->setVisible(false);
 
-  widget_->setWindowTitle("RViz[*]");
-  if (context.serialNumber() != 1)
-  {
-    widget_->setWindowTitle(widget_->windowTitle() + " (" + QString::number(context.serialNumber()) + ")");
-  }
   context.addWidget(widget_);
 
   // trigger deleteLater for plugin when widget or frame is closed
@@ -109,6 +104,9 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
 
 void RViz::onDisplayConfigChanged(const QString& fullpath) {
   display_config_ = fullpath.toStdString();
+
+  if (context_->serialNumber() != 1 && !widget_->windowTitle().endsWith(")"))
+    widget_->setWindowTitle(widget_->windowTitle() + " (" + QString::number(context_->serialNumber()) + ")");
 }
 
 void RViz::parseArguments()

--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -91,28 +91,9 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   widget_->initialize(display_config_.c_str());
 
   // disable quit action in menu bar
-  QMenu* menu = 0;
-  {
-    // find first menu in menu bar
-    const QObjectList& children = menu_bar_->children();
-    for (QObjectList::const_iterator it = children.begin(); !menu && it != children.end(); it++)
-    {
-      menu = dynamic_cast<QMenu*>(*it);
-    }
-  }
-  if (menu)
-  {
-    // hide last action in menu
-    const QObjectList& children = menu->children();
-    if (!children.empty())
-    {
-      QAction* action = dynamic_cast<QAction*>(children.last());
-      if (action)
-      {
-        action->setVisible(false);
-      }
-    }
-  }
+  QAction* action = menu_bar_->findChild<QAction*>("actQuit");
+  if (action)
+    action->setVisible(false);
 
   widget_->setWindowTitle("RViz[*]");
   if (context.serialNumber() != 1)

--- a/src/rqt_rviz/rviz.cpp
+++ b/src/rqt_rviz/rviz.cpp
@@ -86,6 +86,7 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   menu_bar_->setNativeMenuBar(false);
   menu_bar_->setVisible(!hide_menu_);
   widget_->setMenuBar(menu_bar_);
+  widget_->setSplashPath(QString());
 
   widget_->initialize(display_config_.c_str());
 


### PR DESCRIPTION
This PR comprises several independent commits to improve code and fix some open issues:
- Suppress rviz splash screen: The rqt plugin shouldn't show the splash screen. Multiple rviz plugins showed the splash screen multiple times...
- Having defined a name for the quit action in rviz (https://github.com/ros-visualization/rviz/pull/1637), the action can be easily found (and removed) by name.
- `Notice changes of display config file`: When a new display config file was loaded via rviz' menu, the new name was reflected in the widget's title, but not saved to rqt's perspective. This also draws on https://github.com/ros-visualization/rviz/pull/1637
- `Correctly update window title with context serial no`: The old code was appending a serial no to the widget's title once.
  However, if rviz changed the widget title (after loading a new display config), the serial no wasn't added again.

**This PR should be merged into a new melodic-devel branch.**